### PR TITLE
Arcspc 514 Top Container 'sticky' search field and search results

### DIFF
--- a/frontend/app/controllers/repositories_controller.rb
+++ b/frontend/app/controllers/repositories_controller.rb
@@ -104,6 +104,9 @@ class RepositoriesController < ApplicationController
   end
 
   def select
+    # Clear top container previous search when switching repositories
+    session[:top_container_previous_search] = {}
+
     selected = @repositories.find {|r| r.id.to_s == params[:id]}
     self.class.session_repo(session, selected.uri, selected.slug)
     set_user_repository_cookie selected.uri

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -10,6 +10,31 @@ class TopContainersController < ApplicationController
 
 
   def index
+    # If there was a previous top_container search, we prepopulate the form with the filled-in linkers and a search is executed in top_containers.bulk.js
+    @top_container_previous_search = {}
+
+    if session[:top_container_previous_search] && session[:top_container_previous_search] != {}
+      if session[:top_container_previous_search]["resource"]
+        @top_container_previous_search["resource"] = session[:top_container_previous_search]["resource"]
+        @top_container_previous_search["resource"]["id"] = @top_container_previous_search["resource"]["uri"]
+      end
+
+      if session[:top_container_previous_search]["accession"]
+        @top_container_previous_search["accession"] = session[:top_container_previous_search]["accession"]
+        @top_container_previous_search["accession"]["id"] = @top_container_previous_search["accession"]["uri"]
+      end
+
+      if session[:top_container_previous_search]["container_profile"]
+        @top_container_previous_search["container_profile"] = session[:top_container_previous_search]["container_profile"]
+        @top_container_previous_search["container_profile"]["id"] = @top_container_previous_search["container_profile"]["uri"]
+      end
+
+      if session[:top_container_previous_search]["location"]
+        @top_container_previous_search["location"] = session[:top_container_previous_search]["location"]
+        @top_container_previous_search["location"]["id"] = @top_container_previous_search["location"]["uri"]
+      end
+    end
+
   end
 
 
@@ -109,6 +134,46 @@ class TopContainersController < ApplicationController
 
 
   def bulk_operation_search
+    session[:top_container_previous_search] = {}
+    
+    # Store ONLY needed information from linkers in rails session so it can be repopulated for another search later
+    # (The whole record is not saved because they are too big for the rails session and only a few pieces of info are used)
+    if params['collection_resource']
+      previous_resource = JSON.parse(params["collection_resource"]["_resolved"])
+      session[:top_container_previous_search]["resource"] = {
+          "uri" => previous_resource["uri"],
+          "title" => previous_resource["title"],
+          "jsonmodel_type" => previous_resource["jsonmodel_type"]
+        }
+    end
+
+    if params["collection_accession"]
+      previous_accession  = JSON.parse(params['collection_accession']['_resolved'])
+      session[:top_container_previous_search]["accession"] = {
+        "uri" => previous_accession["uri"],
+        "title" => previous_accession["title"],
+        "jsonmodel_type" => previous_accession["jsonmodel_type"]
+      }
+    end
+
+    if params["container_profile"]
+      previous_container_profile = JSON.parse(params['container_profile']['_resolved'])
+      session[:top_container_previous_search]["container_profile"] = {
+        "uri" => previous_container_profile["uri"],
+        "title" => previous_container_profile["title"],
+        "jsonmodel_type" => previous_container_profile["jsonmodel_type"]
+      }
+    end
+
+    if params["location"]
+      previous_location = JSON.parse(params['location']['_resolved'])
+      session[:top_container_previous_search]['location'] = {
+        "uri" => previous_location["uri"],
+        "title" => previous_location["title"],
+        "jsonmodel_type" => previous_location["jsonmodel_type"]
+      }
+    end
+
     begin
       results = perform_search
     rescue MissingFilterException

--- a/frontend/app/views/top_containers/bulk_operations/_collection_accession_linker.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_collection_accession_linker.erb
@@ -1,10 +1,11 @@
 <%
-   if params['collection_accession'].blank?
+   if params['collection_accession'].blank? && !@top_container_previous_search["accession"]
      selected_json = "{}"
+   elsif @top_container_previous_search["accession"]
+     selected_json = @top_container_previous_search["accession"].to_json
    else
      selected_json = params['collection_accession']['_resolved']
    end
-
 %>
 
 <div class="input-group linker-wrapper">

--- a/frontend/app/views/top_containers/bulk_operations/_collection_resource_linker.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_collection_resource_linker.erb
@@ -1,10 +1,11 @@
 <%
-   if params['collection_resource'].blank?
+   if params['collection_resource'].blank? && !@top_container_previous_search["resource"]
      selected_json = "{}"
+   elsif @top_container_previous_search["resource"]
+     selected_json = @top_container_previous_search["resource"].to_json
    else
      selected_json = params['collection_resource']['_resolved']
    end
-
 %>
 
 <div class="input-group linker-wrapper">

--- a/frontend/app/views/top_containers/bulk_operations/_container_profile_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_container_profile_linker.html.erb
@@ -1,12 +1,13 @@
 <%
-   if params['container_profile'].blank?
-     selected_json = "{}"
-   else
-     selected_json = params['container_profile']['_resolved']
-   end
+  if params['container_profile'].blank? && !@top_container_previous_search["container_profile"]
+    selected_json = "{}"
+  elsif @top_container_previous_search["container_profile"]
+    selected_json = @top_container_previous_search["container_profile"].to_json
+  else
+    selected_json = params['container_profile']['_resolved']
+  end
 
-   linkable_types = ["container_profile"]
-
+  linkable_types = ["container_profile"]
 %>
 
 <div class="input-group linker-wrapper">

--- a/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
+++ b/frontend/app/views/top_containers/bulk_operations/_location_linker.html.erb
@@ -1,11 +1,13 @@
 <%
-   if params['location'].blank?
-     selected_json = "{}"
-   else
-     selected_json = params['location']['_resolved']
-   end
+  if params['location'].blank? && !@top_container_previous_search["location"]
+    selected_json = "{}"
+  elsif @top_container_previous_search["location"]
+    selected_json = @top_container_previous_search["location"].to_json
+  else
+    selected_json = params['location']['_resolved']
+  end
 
-   linkable_types = ["location"]
+  linkable_types = ["location"]
 
   path = "location" if path.blank?
   show_create_link = false if show_create_link.blank?


### PR DESCRIPTION
Retains the search parameters and search results in the top container when navigating away and returning to the search screen.  

## Description
<!--- Describe your changes in detail -->
Some items are saved in the sessionStore using JavaScript while others are stored in the session through the Ruby code (the values that have linkers attached to them)
<!--- Why is this change required? What problem does it solve? -->
This helps the end user reuse their search without having to reenter the parameters each time s/he returns to the page.

## Related JIRA Ticket
https://jira.huit.harvard.edu/browse/ARCSPC-514

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Testing was a visual test that displayed the expected outcome.
<!--- see how your change affects other areas of the code, etc. -->
This should not affect any other areas of code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:(I did not verify these yet - will do so prior to submitting to the main ASpace project)
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
