### PR TITLE
ARCSPC 672 fix searching for top container from within container instance

### DIFF
--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -95,11 +95,13 @@ class TopContainersController < ApplicationController
 
   def typeahead
     search_params = params_for_backend_search
+    search_params["q"] = "*" + search_params["q"].gsub(" ", "")
 
-    search_params["q"] = "display_string:#{search_params["q"]}"
+    search_params["q"] = "top_container_u_typeahead_utext:#{search_params["q"]}"
 
     search_params = search_params.merge(search_filter_for(params[:uri]))
-    search_params = search_params.merge("sort" => "typeahead_sort_key_u_sort asc")
+
+    search_params = search_params.merge("sort" => "top_container_u_typeahead_utext asc")
 
     render :json => Search.all(session[:repo_id], search_params)
   end

--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -95,7 +95,7 @@ class TopContainersController < ApplicationController
 
   def typeahead
     search_params = params_for_backend_search
-    search_params["q"] = "*" + search_params["q"].gsub(" ", "")
+    search_params["q"] = "*" + search_params["q"].gsub(/[^0-9A-Za-z]/, '').downcase + "*"
 
     search_params["q"] = "top_container_u_typeahead_utext:#{search_params["q"]}"
 

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -576,7 +576,7 @@ class IndexerCommon
         doc['exported_u_sbool'] = record['record'].has_key?('exported_to_ils')
         doc['empty_u_sbool'] = record['record']['collection'].empty?
 
-        doc['typeahead_sort_key_u_sort'] = record['record']['indicator'].to_s.rjust(255, '#')
+        doc['top_container_u_typeahead_utext'] = "#{record['record']['type'] ? record['record']['type'] : ''} #{record['record']['indicator']}".gsub(" ", "")
         doc['barcode_u_sstr'] = record['record']['barcode']
 
         doc['created_for_collection_u_sstr'] = record['record']['created_for_collection']

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -576,7 +576,7 @@ class IndexerCommon
         doc['exported_u_sbool'] = record['record'].has_key?('exported_to_ils')
         doc['empty_u_sbool'] = record['record']['collection'].empty?
 
-        doc['top_container_u_typeahead_utext'] = "#{record['record']['type'] ? record['record']['type'] : ''} #{record['record']['indicator']}".gsub(" ", "")
+        doc['top_container_u_typeahead_utext'] = record['record']['display_string'].gsub(/[^0-9A-Za-z]/, '').downcase
         doc['barcode_u_sstr'] = record['record']['barcode']
 
         doc['created_for_collection_u_sstr'] = record['record']['created_for_collection']

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -249,6 +249,9 @@
    <dynamicField name="*_u_sort"  type="sort_string"  indexed="true"  stored="false" multiValued="false"/>
    <dynamicField name="*_u_ssort"  type="sort_string"  indexed="true"  stored="true" multiValued="false"/>
 
+   <!-- Field for searching/sorting top container typeahead -->
+   <dynamicField name="*_u_typeahead_utext"  type="text_general"  indexed="true"  stored="true" multiValued="false"/>
+
    <!-- ASpace Custom Dynamics -->
    <dynamicField name="*_relator_sort"  type="sort_string"  indexed="true"  stored="true" multiValued="false"/>
 


### PR DESCRIPTION
## Description
When adding a top container from a resource instance page, the typeahead was behaving erratically, with inaccurate results and a strange sort. This fix creates a solr typeahead search field for top containers and makes the results behave more as you'd expect from a typeahead. 

## Related JIRA Ticket or GitHub Issue
https://jira.huit.harvard.edu/browse/ARCSPC-672

## How Has This Been Tested?
Manual testing of many differently formatted types of container display names.
This change should not affect any other areas of code, since it uses a new solr field (which could likely be used to improve other typeaheads but that's not implemented currently). A reindexing is required for the change.

## Screenshots (if appropriate):
![Screen Shot 2020-02-07 at 11 23 05 AM](https://user-images.githubusercontent.com/46659222/74050034-4c7d5300-49a3-11ea-95bf-9f76bf7f79e5.png)
![Screen Shot 2020-02-07 at 12 06 26 PM](https://user-images.githubusercontent.com/46659222/74050035-4c7d5300-49a3-11ea-96ae-9a0ffb0fcc5f.png)
![Screen Shot 2020-02-07 at 12 11 07 PM](https://user-images.githubusercontent.com/46659222/74050036-4c7d5300-49a3-11ea-89b1-53ee3e807308.png)
![Screen Shot 2020-02-07 at 12 12 48 PM](https://user-images.githubusercontent.com/46659222/74050037-4c7d5300-49a3-11ea-9023-ed9d00bd3f90.png)
![Screen Shot 2020-02-07 at 12 13 07 PM](https://user-images.githubusercontent.com/46659222/74050038-4d15e980-49a3-11ea-949f-554a229892dd.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
