### PR TITLE
Arcspc 668 fix indicator column sort in manage top containers

### DIFF
--- a/frontend/app/assets/javascripts/top_containers.bulk.js
+++ b/frontend/app/assets/javascripts/top_containers.bulk.js
@@ -116,32 +116,29 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
       return value
     }
 
-    let letterOrNumber = isNaN(parseInt(value[0])) ? "letter" : "number"
+    let isNumber = isNaN(parseInt(value[0])) ? false : true
 
     let valueArray = [value[0]]
     let valueArrayCurrentIndex = 0;
     for (i = 1; i < value.length; i++) {
-      switch (letterOrNumber) {
-        case "letter":
-          if (isNaN(parseInt(value[i]))) {
-            valueArray[valueArrayCurrentIndex] += value[i]
-          } else {
-            valueArray[valueArrayCurrentIndex] = valueArray[valueArrayCurrentIndex].trim()
-            valueArrayCurrentIndex += 1
-            valueArray[valueArrayCurrentIndex] = value[i]
-            letterOrNumber = "number"
-          }
-          break;
-        case "number":
-          if (isNaN(parseInt(value[i]))) {
-            valueArray[valueArrayCurrentIndex] = padNumber(valueArray[valueArrayCurrentIndex])
-            valueArrayCurrentIndex += 1
-            valueArray[valueArrayCurrentIndex] = value[i]
-            letterOrNumber = "letter"
-          } else {
-            valueArray[valueArrayCurrentIndex] += value[i]
-          }
-          break;
+      if (!isNumber) {
+        if (isNaN(parseInt(value[i]))) {
+          valueArray[valueArrayCurrentIndex] += value[i]
+        } else {
+          valueArray[valueArrayCurrentIndex] = valueArray[valueArrayCurrentIndex].trim()
+          valueArrayCurrentIndex += 1
+          valueArray[valueArrayCurrentIndex] = value[i]
+          isNumber = true
+        }
+      } else {
+        if (isNaN(parseInt(value[i]))) {
+          valueArray[valueArrayCurrentIndex] = padNumber(valueArray[valueArrayCurrentIndex])
+          valueArrayCurrentIndex += 1
+          valueArray[valueArrayCurrentIndex] = value[i]
+          isNumber = false
+        } else {
+          valueArray[valueArrayCurrentIndex] += value[i]
+        }
       }
     }
 
@@ -179,7 +176,8 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
       } else if ($node.hasClass("top-container-indicator")) {
         var value = $node.text().trim();
         
-        // pad the indicator values so they sort correctly with digit and alpha values
+        // turn the indicator into a string of alternating non-number/padded-number values separated by commas for sorting
+        // eg "box,#############11,folder,#############4"
         return parseIndicator(value);
       }
 

--- a/frontend/app/assets/javascripts/top_containers.bulk.js
+++ b/frontend/app/assets/javascripts/top_containers.bulk.js
@@ -116,7 +116,7 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
       return value
     }
 
-    let isNumber = isNaN(parseInt(value[0])) ? false : true
+    let isNumber = !isNaN(parseInt(value[0]))
 
     let valueArray = [value[0]]
     let valueArrayCurrentIndex = 0;


### PR DESCRIPTION
## Description
The indicator sort column in the Top Containers search results was sorting oddly, which was caused by its padding of the indicator value to a length of 255 characters. This was fine for indicators that were pure numbers (preventing them from being sorted in 1, 10, 2 order), but was causing lots of oddities when other characters and words were involved. This change fixes that by generating, for each indicator, a string composed of alternating non-number/padded-number strings separated by commas. For example: `"box,##############10,folder,##############11"`

## Related JIRA Ticket or GitHub Issue
https://jira.huit.harvard.edu/browse/ARCSPC-668

## How Has This Been Tested?
Manual/visual testing of sort with several differently formatted datasets.
No other code should be affected as the Top Container's search result table's sorting is isolated from the rest of the app, and the indicator was a special case even within that table.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
