### PR TITLE
Arcspc 666 - Put Type above Indicator, top container view

### DIFF
--- a/frontend/app/views/top_containers/show.html.erb
+++ b/frontend/app/views/top_containers/show.html.erb
@@ -27,10 +27,10 @@
             </div>
           <% end %>
 
+          <%= readonly.label_and_textarea "type" %>
           <%= readonly.label_and_textarea "indicator" %>
 
           <%= readonly.label_and_textarea "barcode" %>
-          <%= readonly.label_and_textarea "type" %>
 
           <%= readonly.label_and_textarea "ils_holding_id" %>
           <%= readonly.label_and_textarea "ils_item_id" %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
In the top container "edit" form the Container Type precedes the Indicator field, but the inverse was true in the "view" page. This simple fix changes that to show the Container Type above Indicator on the "view" page as well.
## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->
https://jira.huit.harvard.edu/projects/ARCSPC/issues/ARCSPC-666
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing was a visual test that displayed the expected outcome.

This should not affect any other areas of code.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
