### PR TITLE
Arcspc 846 prepopulate search for resource when browsing for containers

### DIFF
--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -278,25 +278,18 @@ $(function() {
       var tokensForPrepopulation = function() {
         if ($this.data("multiplicity") === "one") {
 
-          // HERE IS WHERE I WILL START DOING THE THING
+          // If we are on a resource edit page, and open a top_container modal with a collection_resource linker
+          // then we prepopulate the collection_resource field with resource data necessary to perform the search
           let currentPath = window.location.pathname;
-          // If we are on a resource edit page, have an open modal with a collection_resource linker
-          // and are current looking at that specific linker with $this...
-
-
-          // THE BELOW WORKS AND WORKS WHEN SEARCH IS CLICKED. NEXT, WE HAVE TO FIND WHEN TO TRIGGER THE SEARCH
-          // BELOW IS THE JQUERY TO CLICK THE BUTTON: 
-          // $(".modal-dialog").find("input[type='submit']").click()
-          // AHHHHHH
-
           if (currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".modal-dialog").find("#collection_resource").length > 0 && $this[0].id === "collection_resource") {
+            let currentForm = $("#object_container").find("form").first()
             return [{
-              id: "/repositories/3/resources/9610",
-              name: "Economic Botany Artifacts, Prints and Posters Amber and Amberoid Collection (TEST)",
+              id: currentForm.attr("data-update-monitor-record-uri"),
+              name: $("#resource_title_").text(),
               json: {
-                id: "/repositories/3/resources/9610",
-                uri: "/repositories/3/resources/9610",
-                title: "Economic Botany Artifacts, Prints and Posters Amber and Amberoid Collection (TEST)",
+                id: currentForm.attr("data-update-monitor-record-uri"),
+                uri: currentForm.attr("data-update-monitor-record-uri"),
+                title: $("#resource_title_").text(),
                 jsonmodel_type: "resource"
               }
             }]
@@ -311,8 +304,6 @@ $(function() {
               name: $this.data("selected").display_string || $this.data("selected").title,
               json: $this.data("selected")
           }];
-
-          // HERE IS WHERE I WILL BE DONE DOING THE THING
 
         } else {
           if (!$this.data("selected") || $this.data("selected").length === 0) {
@@ -438,8 +429,12 @@ $(function() {
             enableSorting();
             $linkerWrapper.addClass("sortable");
           }
+
+          // This is part of automatically executing a search for the current resource on the browse top containers modal when opened from the edit resource page.
           let currentPath = window.location.pathname
-          if ($this.context.dataset.label === "Location" && currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".modal-dialog").find("#collection_resource").length > 0 && $(".modal-dialog").find(".table-search-results").length < 1) {
+          // If this setTimeout is for the last linker in the modal, only then is it safe to execute the search
+          let lastLinker = $(".modal-dialog").find(".linker").last()
+          if (lastLinker.attr("id") === $this.context.id && currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".modal-dialog").find("#collection_resource").length > 0 && $(".modal-dialog").find(".table-search-results").length < 1) {
             $(".modal-dialog").find("input[type='submit']").click()
           }
         });

--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -34,11 +34,13 @@ $(function() {
         types: $this.data("types"),
         exclude_ids: $this.data("exclude") || []
       };
+
       config.allow_multiple = config.multiplicity === "many";
 
       if (config.format_template && config.format_template.substring(0,2) != "${") {
         config.format_template = "${" + config.format_template + "}";
       }
+
       var renderCreateFormForObject = function(form_uri) {
         var $modal = $("#"+config.modal_id);
 
@@ -124,6 +126,7 @@ $(function() {
               var $modal = $("#"+config.modal_id);
 
               var $linkerBrowseContainer = $(".linker-container", $modal);
+
               var initBrowseFormInputs = function() {
                 // add some click handlers to allow clicking of the row
                 $(":input[name=linker-item]", $linkerBrowseContainer).each(function() {
@@ -148,8 +151,10 @@ $(function() {
                       $input.closest("tr").addClass("selected");
                     }
                   });
+
                   $("td", $input.closest("tr")).click(function(event) {
                     event.preventDefault();
+
                     $input.trigger("click");
                   });
                 });
@@ -160,12 +165,14 @@ $(function() {
                     .attr("checked","checked")
                     .closest("tr").addClass("selected");
                 });
+
                 $modal.trigger("resize");
               };
 
               $linkerBrowseContainer.html(html);
               $($linkerBrowseContainer).on("click", "a", function(event) {
                 event.preventDefault();
+
                 $linkerBrowseContainer.load(event.target.href, initBrowseFormInputs);
               });
 
@@ -174,6 +181,7 @@ $(function() {
 
                 var $form = $(event.target);
                 var method = ($form.attr("method") || "get").toUpperCase();
+
 
                 if (method == "POST") {
                   jQuery.post($form.attr("action") + ".js",
@@ -215,7 +223,6 @@ $(function() {
         $("#"+config.modal_id).on("click", ".linker-list .pagination .navigation a", function() {
           renderItemsInModal($(this).attr("rel"));
         });
-        // $(".modal-dialog").find("input[type='submit']").click()
         return false; // IE patch
       };
 
@@ -298,13 +305,11 @@ $(function() {
           if ($.isEmptyObject($this.data("selected"))) {
             return [];
           }
-
           return [{
               id: $this.data("selected").uri,
               name: $this.data("selected").display_string || $this.data("selected").title,
               json: $this.data("selected")
           }];
-
         } else {
           if (!$this.data("selected") || $this.data("selected").length === 0) {
             return [];
@@ -438,10 +443,11 @@ $(function() {
             $(".modal-dialog").find("input[type='submit']").click()
           }
         });
+
         addEventBindings();
       };
+
       init();
-      
     });
   };
 });
@@ -458,5 +464,3 @@ $(document).ready(function() {
     $(".linker:not(.initialised)", subform).linker();
   });
 });
-
-// $(".modal-dialog").find("input[type='submit']").click()

--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -288,7 +288,7 @@ $(function() {
           // If we are on a resource edit page, and open a top_container modal with a collection_resource linker
           // then we prepopulate the collection_resource field with resource data necessary to perform the search
           let currentPath = window.location.pathname;
-          if (currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".modal-dialog").find("#collection_resource").length > 0 && $this[0].id === "collection_resource") {
+          if (currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".label.label-info").text() === "Resource" && $(".modal-dialog").find("#collection_resource").length > 0 && $this[0].id === "collection_resource") {
             let currentForm = $("#object_container").find("form").first()
             return [{
               id: currentForm.attr("data-update-monitor-record-uri"),
@@ -439,7 +439,7 @@ $(function() {
           let currentPath = window.location.pathname
           // If this setTimeout is for the last linker in the modal, only then is it safe to execute the search
           let lastLinker = $(".modal-dialog").find(".linker").last()
-          if (lastLinker.attr("id") === $this.context.id && currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".modal-dialog").find("#collection_resource").length > 0 && $(".modal-dialog").find(".table-search-results").length < 1) {
+          if (lastLinker.attr("id") === $this.context.id && currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".label.label-info").text() === "Resource" && $(".modal-dialog").find("#collection_resource").length > 0 && $(".modal-dialog").find(".table-search-results").length < 1) {
             $(".modal-dialog").find("input[type='submit']").click()
           }
         });

--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -34,13 +34,11 @@ $(function() {
         types: $this.data("types"),
         exclude_ids: $this.data("exclude") || []
       };
-
       config.allow_multiple = config.multiplicity === "many";
 
       if (config.format_template && config.format_template.substring(0,2) != "${") {
         config.format_template = "${" + config.format_template + "}";
       }
-
       var renderCreateFormForObject = function(form_uri) {
         var $modal = $("#"+config.modal_id);
 
@@ -126,7 +124,6 @@ $(function() {
               var $modal = $("#"+config.modal_id);
 
               var $linkerBrowseContainer = $(".linker-container", $modal);
-
               var initBrowseFormInputs = function() {
                 // add some click handlers to allow clicking of the row
                 $(":input[name=linker-item]", $linkerBrowseContainer).each(function() {
@@ -151,10 +148,8 @@ $(function() {
                       $input.closest("tr").addClass("selected");
                     }
                   });
-
                   $("td", $input.closest("tr")).click(function(event) {
                     event.preventDefault();
-
                     $input.trigger("click");
                   });
                 });
@@ -165,14 +160,12 @@ $(function() {
                     .attr("checked","checked")
                     .closest("tr").addClass("selected");
                 });
-
                 $modal.trigger("resize");
               };
 
               $linkerBrowseContainer.html(html);
               $($linkerBrowseContainer).on("click", "a", function(event) {
                 event.preventDefault();
-
                 $linkerBrowseContainer.load(event.target.href, initBrowseFormInputs);
               });
 
@@ -181,7 +174,6 @@ $(function() {
 
                 var $form = $(event.target);
                 var method = ($form.attr("method") || "get").toUpperCase();
-
 
                 if (method == "POST") {
                   jQuery.post($form.attr("action") + ".js",
@@ -223,6 +215,7 @@ $(function() {
         $("#"+config.modal_id).on("click", ".linker-list .pagination .navigation a", function() {
           renderItemsInModal($(this).attr("rel"));
         });
+        // $(".modal-dialog").find("input[type='submit']").click()
         return false; // IE patch
       };
 
@@ -284,14 +277,43 @@ $(function() {
 
       var tokensForPrepopulation = function() {
         if ($this.data("multiplicity") === "one") {
+
+          // HERE IS WHERE I WILL START DOING THE THING
+          let currentPath = window.location.pathname;
+          // If we are on a resource edit page, have an open modal with a collection_resource linker
+          // and are current looking at that specific linker with $this...
+
+
+          // THE BELOW WORKS AND WORKS WHEN SEARCH IS CLICKED. NEXT, WE HAVE TO FIND WHEN TO TRIGGER THE SEARCH
+          // BELOW IS THE JQUERY TO CLICK THE BUTTON: 
+          // $(".modal-dialog").find("input[type='submit']").click()
+          // AHHHHHH
+
+          if (currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".modal-dialog").find("#collection_resource").length > 0 && $this[0].id === "collection_resource") {
+            return [{
+              id: "/repositories/3/resources/9610",
+              name: "Economic Botany Artifacts, Prints and Posters Amber and Amberoid Collection (TEST)",
+              json: {
+                id: "/repositories/3/resources/9610",
+                uri: "/repositories/3/resources/9610",
+                title: "Economic Botany Artifacts, Prints and Posters Amber and Amberoid Collection (TEST)",
+                jsonmodel_type: "resource"
+              }
+            }]
+          }
+
           if ($.isEmptyObject($this.data("selected"))) {
             return [];
           }
+
           return [{
               id: $this.data("selected").uri,
               name: $this.data("selected").display_string || $this.data("selected").title,
               json: $this.data("selected")
           }];
+
+          // HERE IS WHERE I WILL BE DONE DOING THE THING
+
         } else {
           if (!$this.data("selected") || $this.data("selected").length === 0) {
             return [];
@@ -416,12 +438,15 @@ $(function() {
             enableSorting();
             $linkerWrapper.addClass("sortable");
           }
+          let currentPath = window.location.pathname
+          if ($this.context.dataset.label === "Location" && currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".modal-dialog").find("#collection_resource").length > 0 && $(".modal-dialog").find(".table-search-results").length < 1) {
+            $(".modal-dialog").find("input[type='submit']").click()
+          }
         });
-
         addEventBindings();
       };
-
       init();
+      
     });
   };
 });
@@ -438,3 +463,5 @@ $(document).ready(function() {
     $(".linker:not(.initialised)", subform).linker();
   });
 });
+
+// $(".modal-dialog").find("input[type='submit']").click()

--- a/frontend/app/assets/javascripts/linker.js
+++ b/frontend/app/assets/javascripts/linker.js
@@ -1,6 +1,9 @@
 //= require jquery.tokeninput
 
 $(function() {
+  let resource_edit_path_regex = /^\/resources\/\d+\/edit$/
+  let on_resource_edit_path = window.location.pathname.match(resource_edit_path_regex)
+
   $.fn.linker = function() {
     $(this).each(function() {
       var $this = $(this);
@@ -287,8 +290,11 @@ $(function() {
 
           // If we are on a resource edit page, and open a top_container modal with a collection_resource linker
           // then we prepopulate the collection_resource field with resource data necessary to perform the search
-          let currentPath = window.location.pathname;
-          if (currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".label.label-info").text() === "Resource" && $(".modal-dialog").find("#collection_resource").length > 0 && $this[0].id === "collection_resource") {
+          let onResource = $(".label.label-info").text() === "Resource"
+          let modalHasResource = $(".modal-dialog").find("#collection_resource").length > 0
+          let idMatches = $this[0].id === "collection_resource"
+          
+          if (on_resource_edit_path && onResource && modalHasResource && idMatches) {
             let currentForm = $("#object_container").find("form").first()
             return [{
               id: currentForm.attr("data-update-monitor-record-uri"),
@@ -436,10 +442,14 @@ $(function() {
           }
 
           // This is part of automatically executing a search for the current resource on the browse top containers modal when opened from the edit resource page.
-          let currentPath = window.location.pathname
           // If this setTimeout is for the last linker in the modal, only then is it safe to execute the search
           let lastLinker = $(".modal-dialog").find(".linker").last()
-          if (lastLinker.attr("id") === $this.context.id && currentPath.match(/^\/resources\/[\s\S]*\/edit$/) && $(".label.label-info").text() === "Resource" && $(".modal-dialog").find("#collection_resource").length > 0 && $(".modal-dialog").find(".table-search-results").length < 1) {
+          let isLastLinker = lastLinker.attr("id") === $this.context.id
+          let onResource = $(".label.label-info").text() === "Resource"
+          let modalHasResource = $(".modal-dialog").find("#collection_resource").length > 0
+          let resultsEmpty = $(".modal-dialog").find(".table-search-results").length < 1
+
+          if (on_resource_edit_path && onResource && modalHasResource && resultsEmpty && isLastLinker) {
             $(".modal-dialog").find("input[type='submit']").click()
           }
         });


### PR DESCRIPTION
## Description
When using the Browse modal to link a top container to a resource, this will prepopulate the modal with the search results for that resource. The original search fields and functionality are all intact.

## Related JIRA Ticket or GitHub Issue
https://jira.huit.harvard.edu/browse/ARCSPC-846

## How Has This Been Tested?
Manual testing. This shouldn't affect other areas of code, I was maybe overcautious with the conditionals to make sure.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
