### PR TITLE
ARCSPC 672 - improvement to typeahead results sort

### DIFF
--- a/frontend/app/controllers/top_containers_controller.rb
+++ b/frontend/app/controllers/top_containers_controller.rb
@@ -126,7 +126,7 @@ class TopContainersController < ApplicationController
 
     search_params = search_params.merge(search_filter_for(params[:uri]))
 
-    search_params = search_params.merge("sort" => "top_container_u_typeahead_utext asc")
+    search_params = search_params.merge("sort" => "top_container_u_typeahead_usort asc")
 
     render :json => Search.all(session[:repo_id], search_params)
   end

--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -585,6 +585,7 @@ class IndexerCommon
         doc['empty_u_sbool'] = record['record']['collection'].empty?
 
         doc['top_container_u_typeahead_utext'] = record['record']['display_string'].gsub(/[^0-9A-Za-z]/, '').downcase
+        doc['top_container_u_typeahead_usort'] = record['record']['display_string']
         doc['barcode_u_sstr'] = record['record']['barcode']
 
         doc['created_for_collection_u_sstr'] = record['record']['created_for_collection']

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -260,6 +260,7 @@
 
    <!-- Field for searching/sorting top container typeahead -->
    <dynamicField name="*_u_typeahead_utext"  type="text_general"  indexed="true"  stored="true" multiValued="false"/>
+   <dynamicField name="*_u_typeahead_usort"  type="sort_icu"  indexed="true"  stored="true" multiValued="false"/>
 
    <!-- ASpace Custom Dynamics -->
    <dynamicField name="*_relator_sort"  type="sort_string"  indexed="true"  stored="true" multiValued="false"/>


### PR DESCRIPTION
## Description
Further improvements to the typeahead results. On some result sets, the alphanum sort wasn't displaying in an ideal order. I have refactored to utilize the icu_sort field built by Michael for his work on the location field alphanum_sort.

## Related JIRA Ticket or GitHub Issue
https://jira.huit.harvard.edu/browse/ARCSPC-672

## How Has This Been Tested?
Manual testing. 

## Screenshots (if appropriate):
<img width="880" alt="Screen Shot 2020-02-28 at 12 41 01 PM" src="https://user-images.githubusercontent.com/46659222/75571673-a8c61680-5a27-11ea-81f8-2e24c5487910.png"> vs 
<img width="880" alt="Screen Shot 2020-02-28 at 12 41 09 PM" src="https://user-images.githubusercontent.com/46659222/75571684-ad8aca80-5a27-11ea-827a-e3d6c2e2601b.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
