### PR TITLE
Arcspc 952 - Corrected the location bug by reinstating the filters that were

### DIFF
--- a/frontend/app/models/search.rb
+++ b/frontend/app/models/search.rb
@@ -11,6 +11,8 @@ class Search
 
 
   def self.all(repo_id, criteria)
+    build_filters(criteria)
+
     criteria["page"] = 1 if not criteria.has_key?("page")
       
     search_data = JSONModel::HTTP::get_json("/repositories/#{repo_id}/search", criteria)


### PR DESCRIPTION
## Description
A bug from ARCSPC_655 was introduced when some of the filtering logic was inadvertently removed, causing all resources to be returned instead of the relevant top container objects.
<!--- Why is this change required? What problem does it solve? -->
This was a patch to the original branch.

## Related JIRA Ticket or GitHub Issue
https://jira.huit.harvard.edu/browse/ARCSPC-952

## How Has This Been Tested?
Verified that only top containers with the given location are appearing in the table results.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ X] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
