### PR TITLE
ARCSPC_989: Location displayed when viewing/editing Instance on Resource, Archival Object, and Accession

### DIFF
--- a/frontend/app/assets/stylesheets/archivesspace/token-input.less
+++ b/frontend/app/assets/stylesheets/archivesspace/token-input.less
@@ -390,3 +390,7 @@ div.token-input-dropdown ul li.token-input-selected-dropdown-item {
 .prelinker {
   display: none;  
 }
+
+.top_container_location .token {
+  margin-left: 15px;
+}

--- a/frontend/app/controllers/accessions_controller.rb
+++ b/frontend/app/controllers/accessions_controller.rb
@@ -27,6 +27,7 @@ class AccessionsController < ApplicationController
 
   def show
     @accession = fetch_resolved(params[:id])
+
     @accession['accession_date'] = I18n.t('accession.accession_date_unknown') if @accession['accession_date'] == "9999-12-31"
 
     flash[:info] = I18n.t("accession._frontend.messages.suppressed_info", JSONModelI18nWrapper.new(:accession => @accession)) if @accession.suppressed
@@ -182,7 +183,11 @@ class AccessionsController < ApplicationController
 
   # refactoring note: suspiciously similar to resources_controller.rb
   def fetch_resolved(id)
-    accession = Accession.find(id, find_opts)
+    # We add this so that we can get a top container location to display with the instance view
+    new_find_opts = find_opts
+    new_find_opts["resolve[]"].push("top_container::container_locations")
+
+    accession = Accession.find(id, new_find_opts)
 
     if accession['classifications']
       accession['classifications'].each do |classification|

--- a/frontend/app/controllers/archival_objects_controller.rb
+++ b/frontend/app/controllers/archival_objects_controller.rb
@@ -28,7 +28,10 @@ class ArchivalObjectsController < ApplicationController
   end
 
   def edit
-    @archival_object = JSONModel(:archival_object).find(params[:id], find_opts)
+    new_find_opts = find_opts
+    new_find_opts["resolve[]"].push("top_container::container_locations")
+
+    @archival_object = JSONModel(:archival_object).find(params[:id], new_find_opts)
 
     if @archival_object.suppressed
       return redirect_to(:action => :show, :id => params[:id], :inline => params[:inline])
@@ -100,7 +103,11 @@ class ArchivalObjectsController < ApplicationController
 
   def show
     @resource_id = params['resource_id']
-    @archival_object = JSONModel(:archival_object).find(params[:id], find_opts)
+
+    new_find_opts = find_opts
+    new_find_opts["resolve[]"].push("top_container::container_locations")
+
+    @archival_object = JSONModel(:archival_object).find(params[:id], new_find_opts)
 
     flash.now[:info] = I18n.t("archival_object._frontend.messages.suppressed_info", JSONModelI18nWrapper.new(:archival_object => @archival_object).enable_parse_mixed_content!(url_for(:root))) if @archival_object.suppressed
 

--- a/frontend/app/controllers/resources_controller.rb
+++ b/frontend/app/controllers/resources_controller.rb
@@ -361,7 +361,11 @@ class ResourcesController < ApplicationController
 
 # refactoring note: suspiciously similar to accessions_controller.rb
   def fetch_resolved(id)
-    resource = JSONModel(:resource).find(id, find_opts)
+    # We add this so that we can get a top container location to display with the instance view
+    new_find_opts = find_opts
+    new_find_opts["resolve[]"].push("top_container::container_locations")
+    
+    resource = JSONModel(:resource).find(id, new_find_opts)
 
     if resource['classifications']
       resource['classifications'].each do |classification|

--- a/frontend/app/views/container_locations/_show_only_token.html.erb
+++ b/frontend/app/views/container_locations/_show_only_token.html.erb
@@ -1,0 +1,20 @@
+<div class="container-subrecord">
+<% container_locations.each_with_index do |container_location, index| %>
+    <% if container_location['_resolved'] %>
+        <div class="form-group">
+            <div class="control-label">
+                <label class="control-label col-sm-2"><%= I18n.t("container_location._plural") %></label>
+                <div class="controls token-list">
+                    <%= render_token :object => container_location['_resolved'],
+                                        :label => container_location['_resolved']['title'],
+                                        :type => "location",
+                                        :uri => container_location["ref"],
+                                        :placement => "top" %>
+                </div>
+            </div>
+        </div>
+    <% end %>
+    <% if index < container_locations.length-1 %><hr/><% end %>
+<% end %>
+</div>
+

--- a/frontend/app/views/sub_containers/_show.html.erb
+++ b/frontend/app/views/sub_containers/_show.html.erb
@@ -25,3 +25,8 @@
   <%= readonly.emit_template ("sub_container") %>
 <% end %>
 
+<% if sub_container["top_container"]["_resolved"]["container_locations"] && sub_container["top_container"]["_resolved"]["container_locations"].length > 0 %>
+    <%= render_aspace_partial :partial => "container_locations/show_only_token", :locals => { :container_locations => sub_container["top_container"]["_resolved"]["container_locations"] } %>
+<% end %>
+
+

--- a/frontend/app/views/top_containers/_linker.html.erb
+++ b/frontend/app/views/top_containers/_linker.html.erb
@@ -35,6 +35,7 @@
   }
 
 %>
+
 <div class="form-group <% if required %>required<% end %>">
   <label class="control-label col-sm-2"><%= I18n.t("top_container._singular") %></label>
   <div class="controls col-sm-8">
@@ -82,3 +83,12 @@
     </div>
   </div>
 </div>
+
+<div class="top_container_location">
+  <% selected_json_parsed = JSON.parse(selected_json) %>
+
+  <% if selected_json_parsed["container_locations"] && selected_json_parsed["container_locations"].length > 0 %>
+    <%= render_aspace_partial :partial => "container_locations/show_only_token", :locals => { :container_locations => selected_json_parsed["container_locations"] } %>
+  <% end %>
+</div>
+  


### PR DESCRIPTION
## Description
A section with locations that displays a location token link shows up when viewing or editing instances on Resources, Accessions, and Archival Objects.

## Related JIRA Ticket or GitHub Issue
https://jira.huit.harvard.edu/browse/ARCSPC-989

## How Has This Been Tested?
Manual Testing

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
